### PR TITLE
ci: switch Windows jobs to Windows 11 hosted agent

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -122,7 +122,7 @@ stages:
         Release:
           buildType: Release
     pool:
-      vmImage: windows-latest
+      vmImage: windows-11
     steps:
     - checkout: self
 


### PR DESCRIPTION
Updated Azure Pipelines configuration to use the Windows 11 hosted image
instead of windows-latest (Windows Server 2022) for both Windows x64 and
Windows x86 jobs.

- Changed pool.vmImage from `windows-latest` → `windows-11`
- Ensures builds and tests run against Windows 11 environment
- Keeps artifact publishing unchanged
