### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [__main__]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [__main__]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: macos-latest

--- a/.github/workflows/msvc-ci.yml
+++ b/.github/workflows/msvc-ci.yml
@@ -6,6 +6,10 @@ on:
     branches: [ __main__ ]
   workflow_dispatch:
 
+permissions:
+  contents: read
+  packages: read
+
 jobs:
   build:
     runs-on: windows-latest


### PR DESCRIPTION
Potential fix for [https://github.com/zrsx/pycdc/security/code-scanning/3](https://github.com/zrsx/pycdc/security/code-scanning/3)

Add an explicit `permissions` block to the workflow with least privilege needed.  
Best fix here: define workflow-level permissions right after the trigger section and before `jobs`, setting:

- `contents: read` (needed for checkout)
- `packages: read` (safe minimal read permission often recommended; does not grant write)

This preserves existing functionality while ensuring `GITHUB_TOKEN` is explicitly restricted.

File to edit: `.github/workflows/msvc-ci.yml`  
Region: between line 7 (`workflow_dispatch:`) and line 9 (`jobs:`).  
No imports, methods, or additional definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Restrict default GitHub Actions token permissions in CI workflows to address security scanning alerts.

Bug Fixes:
- Constrain GitHub Actions workflow permissions to least privilege to resolve a code scanning warning about missing permissions configuration.

CI:
- Add explicit least-privilege permissions blocks to the Windows, Linux, and macOS CI workflows, limiting the GITHUB_TOKEN to read-only access where required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added explicit permission configurations to CI/CD workflows for Linux, macOS, and MSVC pipelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->